### PR TITLE
Delete item in shopcart

### DIFF
--- a/service/routes.py
+++ b/service/routes.py
@@ -402,3 +402,28 @@ def read_item_from_shopcart(customer_id, item_id):
         abort(status.HTTP_404_NOT_FOUND, f"Item with id {item_id} not found in this shopcart")
 
     return jsonify(item.serialize()), status.HTTP_200_OK
+
+
+##############################################
+# DELETE AN ITEM FROM SHOPCART
+##############################################
+@app.route("/shopcarts/<int:customer_id>/items/<int:item_id>", methods=["DELETE"])
+def delete_item_from_shopcart(customer_id, item_id):
+    """Delete an existing item from a shopcart"""
+    app.logger.info(f"Request to delete item {item_id} from shopcart of customer {customer_id}")
+
+    # 找到该用户的购物车
+    shopcart = Shopcart.find_by_customer_id(customer_id).first()
+    if not shopcart:
+        abort(status.HTTP_404_NOT_FOUND, f"Shopcart for customer {customer_id} not found")
+
+    # 找到该 item
+    item = ShopcartItem.find(item_id)
+    if not item or item.shopcart_id != shopcart.id:
+        abort(status.HTTP_404_NOT_FOUND, f"Item with id {item_id} not found in this shopcart")
+
+    # 删除 item
+    item.delete()
+    app.logger.info(f"Item {item_id} deleted successfully from shopcart {customer_id}")
+
+    return "", status.HTTP_204_NO_CONTENT

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -679,6 +679,27 @@ class TestYourResourceService(TestCase):
         resp = self.client.get("/shopcarts/2/items/1")
         self.assertEqual(resp.status_code, status.HTTP_404_NOT_FOUND)
 
+    def test_delete_item_from_shopcart(self):
+        """It should delete an item from the shopcart"""
+        # create a shopcart and add an item
+        resp = self.client.post("/shopcarts", json={"customer_id": 1, "status": "active"})
+        self.assertEqual(resp.status_code, status.HTTP_201_CREATED)
+
+        resp = self.client.post("/shopcarts/1/items",
+                                json={"product_id": 123, "quantity": 2, "price": 10.5},
+                                content_type="application/json")
+        self.assertEqual(resp.status_code, status.HTTP_201_CREATED)
+        item_id = resp.get_json()["id"]
+
+        # delete the item
+        resp = self.client.delete(f"/shopcarts/1/items/{item_id}")
+        self.assertEqual(resp.status_code, status.HTTP_204_NO_CONTENT)
+
+    def test_delete_nonexistent_item(self):
+        """It should return 404 when deleting a non-existing item"""
+        resp = self.client.delete("/shopcarts/1/items/999")
+        self.assertEqual(resp.status_code, status.HTTP_404_NOT_FOUND)
+
     # ----------------------------------------------------------
     # SUPPORT FUNCTIONS AND ERROR HANDLERS
     # ----------------------------------------------------------


### PR DESCRIPTION
Added DELETE endpoint for removing an item from a shopcart.

- Implemented /shopcarts/<customer_id>/items/<item_id> (DELETE)

- Returns 204 on success, 404 when shopcart or item not found

- Added unit tests and achieved 95%+ coverage