### PR TITLE
Query Shopcarts by Different Parameters

### DIFF
--- a/service/models/shopcart.py
+++ b/service/models/shopcart.py
@@ -16,6 +16,8 @@ EASTERN_ZONE = ZoneInfo("America/New_York")
 class Shopcart(CRUDMixin, db.Model):
     """Represents a customer's shopcart."""
 
+    VALID_STATUSES = frozenset({"active", "abandoned"})
+
     @staticmethod
     def _to_eastern_iso(value):
         """Return an ISO8601 string converted to US Eastern time."""
@@ -295,3 +297,8 @@ class Shopcart(CRUDMixin, db.Model):
         """Returns all Shopcarts with the given status"""
         logger.info("Processing status query for %s ...", status)
         return cls.query.filter(cls.status == status)
+
+    @classmethod
+    def allowed_statuses(cls):
+        """Return the set of valid status values."""
+        return cls.VALID_STATUSES

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -19,7 +19,7 @@ class ShopcartFactory(factory.Factory):
     customer_id = factory.Sequence(lambda n: n + 1)
     created_date = factory.Faker("date_time")
     last_modified = factory.Faker("date_time")
-    status = FuzzyChoice(choices=["active", "abandoned", "completed"])
+    status = FuzzyChoice(choices=["active", "abandoned"])
     total_items = FuzzyInteger(0, 10)
 
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -95,16 +95,16 @@ class TestShopcartModel(TestCase):
         shopcart.create()
         self.assertIsNotNone(shopcart.id)
         # Change it and save it
-        shopcart.status = "completed"
+        shopcart.status = "abandoned"
         original_id = shopcart.id
         shopcart.update()
         self.assertEqual(shopcart.id, original_id)
-        self.assertEqual(shopcart.status, "completed")
+        self.assertEqual(shopcart.status, "abandoned")
         # Fetch it back and make sure the id hasn't changed
         shopcarts = Shopcart.all()
         self.assertEqual(len(shopcarts), 1)
         self.assertEqual(shopcarts[0].id, original_id)
-        self.assertEqual(shopcarts[0].status, "completed")
+        self.assertEqual(shopcarts[0].status, "abandoned")
 
     def test_delete_a_shopcart(self):
         """It should Delete a Shopcart"""


### PR DESCRIPTION
Added richer admin filtering for GET /shopcarts, including status, customer, created-date range, and total-price thresholds, all backed by shared parsing utilities and documented error handling. Introduced lifecycle actions—checkout now exits carts as abandoned, plus new PATCH /shopcarts/<id>/cancel and /reactivate endpoints—with matching tests. Updated factories, models, and README to reflect the streamlined active/abandoned status model and the expanded query surface, keeping lint/tests green (10/10 lint, full pytest pass).